### PR TITLE
🐛 APP-3929: Fix TypeDict import

### DIFF
--- a/src/datarobot_pulumi_utils/schema/llms.py
+++ b/src/datarobot_pulumi_utils/schema/llms.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 from typing import Literal
 
+import pulumi_datarobot as drp
+
 from datarobot_pulumi_utils.schema.base import Field, Schema
-from datarobot_pulumi_utils.schema.vectordb import VectorDatabaseArgs
 
 CredentialType = Literal["azure", "aws", "google", "api"]
 
@@ -71,7 +72,7 @@ class LLMBlueprintArgs(Schema):
     resource_name: str
     description: str | None = None
     llm_id: str
-    llm_settings: LLMSettings | None = None
+    llm_settings: drp.LlmBlueprintLlmSettingsArgs | None = None
     name: str | None = None
     prompt_type: str | None = None
-    vector_database_settings: VectorDatabaseArgs | None = None
+    vector_database_settings: drp.LlmBlueprintVectorDatabaseSettingsArgs | None = None

--- a/src/datarobot_pulumi_utils/schema/llms.py
+++ b/src/datarobot_pulumi_utils/schema/llms.py
@@ -15,9 +15,8 @@ from __future__ import annotations
 
 from typing import Literal
 
-import pulumi_datarobot as drp
-
 from datarobot_pulumi_utils.schema.base import Field, Schema
+from datarobot_pulumi_utils.schema.vectordb import VectorDatabaseArgs
 
 CredentialType = Literal["azure", "aws", "google", "api"]
 
@@ -72,7 +71,7 @@ class LLMBlueprintArgs(Schema):
     resource_name: str
     description: str | None = None
     llm_id: str
-    llm_settings: drp.LlmBlueprintLlmSettingsArgs | None = None
+    llm_settings: LLMSettings | None = None
     name: str | None = None
     prompt_type: str | None = None
-    vector_database_settings: drp.LlmBlueprintVectorDatabaseSettingsArgs | None = None
+    vector_database_settings: VectorDatabaseArgs | None = None

--- a/src/datarobot_pulumi_utils/schema/predictions.py
+++ b/src/datarobot_pulumi_utils/schema/predictions.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import Any, Literal, TypedDict, Union
+import sys
+from typing import Any, Literal, Union
+
+if sys.version_info >= (3, 12):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 from datarobot_pulumi_utils.schema.base import Field, Schema, StrEnum
 


### PR DESCRIPTION
## Summary

Fixed the typedict import for Python <= 3.11:

```
Previewing update (test-template-269):
@ previewing update....

@ previewing update......
 +  pulumi:pulumi:Stack nbo-test-template-269 create 
 +  pulumi:pulumi:Stack nbo-test-template-269 create error: Program failed with an unhandled exception:
 +  pulumi:pulumi:Stack nbo-test-template-269 create 1 error
Diagnostics:
  pulumi:pulumi:Stack (nbo-test-template-269):
    error: Program failed with an unhandled exception:
    Traceback (most recent call last):
      File "/home/notebooks/storage/infra/__main__.py", line 31, in <module>
        from infra import (
      File "/home/notebooks/storage/infra/settings_generative.py", line 26, in <module>
        from datarobot_pulumi_utils.schema.predictions import BaselineValues, CustomMetricArgs
      File "/home/notebooks/storage/.venv/lib/python3.11/site-packages/datarobot_pulumi_utils/schema/predictions.py", line 252, in <module>
        class CustomMetricArgs(Schema):
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_model_construction.py", line 224, in __new__
        complete_model_class(
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_model_construction.py", line 577, in complete_model_class
        schema = cls.__get_pydantic_core_schema__(cls, handler)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/main.py", line 671, in __get_pydantic_core_schema__
        return handler(source)
               ^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_schema_generation_shared.py", line 83, in __call__
        schema = self._handler(source_type)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 655, in generate_schema
        schema = self._generate_schema_inner(obj)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 924, in _generate_schema_inner
        return self._model_schema(obj)
               ^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 739, in _model_schema
        {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 739, in <dictcomp>
        {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1115, in _generate_md_field_schema
        common_field = self._common_field_schema(name, field_info, decorators)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1308, in _common_field_schema
        schema = self._apply_annotations(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 2107, in _apply_annotations
        schema = get_inner_schema(source_type)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_schema_generation_shared.py", line 83, in __call__
        schema = self._handler(source_type)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 2088, in inner_handler
        schema = self._generate_schema_inner(obj)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 929, in _generate_schema_inner
        return self.match_type(obj)
               ^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1029, in match_type
        return self._match_generic_type(obj, origin)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1058, in _match_generic_type
        return self._union_schema(obj)
               ^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1378, in _union_schema
        choices.append(self.generate_schema(arg))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 655, in generate_schema
        schema = self._generate_schema_inner(obj)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 929, in _generate_schema_inner
        return self.match_type(obj)
               ^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1029, in match_type
        return self._match_generic_type(obj, origin)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1062, in _match_generic_type
        return self._list_schema(self._get_first_arg_or_any(obj))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 431, in _list_schema
        return core_schema.list_schema(self.generate_schema(items_type))
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 655, in generate_schema
        schema = self._generate_schema_inner(obj)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 929, in _generate_schema_inner
        return self.match_type(obj)
               ^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 999, in match_type
        return self._typed_dict_schema(obj, None)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/etc/system/kernel/.venv/lib/python3.11/site-packages/pydantic/_internal/_generate_schema.py", line 1461, in _typed_dict_schema
        raise PydanticUserError(
    pydantic.errors.PydanticUserError: Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12.
    
    For further information visit https://errors.pydantic.dev/2.9/u/typed-dict-version

Resources:
    + 1 to create
```


## Rationale
