### PR TITLE
Apply CI jobs on the main branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,14 @@ name: Lint
 
 on:
   push:
-    branches: ["master"]
+    branches:
+      - "master"
+      - "main"
 
   pull_request:
-    branches: ["master"]
+    branches:
+      - "master"
+      - "main"
 
 jobs:
   tests:


### PR DESCRIPTION
## Summary

Apply Ci jobs on the main branch (after branch renaming).
