### PR TITLE
[BUZZOK-26081] Add GenAI Agents runtime environment to pulumi utils

### DIFF
--- a/src/datarobot_pulumi_utils/schema/exec_envs.py
+++ b/src/datarobot_pulumi_utils/schema/exec_envs.py
@@ -48,6 +48,7 @@ class RuntimeEnvironments(Enum):
     PYTHON_39_CUSTOM_METRICS = RuntimeEnvironment(name="[DataRobot] Python 3.9 Custom Metrics Templates Drop-In")
     PYTHON_311_NOTEBOOK_DROP_IN = RuntimeEnvironment(name="[DataRobot] Python 3.11 Notebook Drop-In")
     PYTHON_39_STREAMLIT = RuntimeEnvironment(name="[Experimental] Python 3.9 Streamlit")
+    PYTHON_311_GENAI_AGENTS = RuntimeEnvironment(name="[DataRobot] Python 3.11 GenAI Agents")
     PYTHON_311_GENAI = RuntimeEnvironment(name="[DataRobot] Python 3.11 GenAI")
     PYTHON_39_GENAI = RuntimeEnvironment(name="[DataRobot] Python 3.9 GenAI")
     PYTHON_39_ONNX = RuntimeEnvironment(name="[DataRobot] Python 3.9 ONNX Drop-In")


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
We want to allow this environment to be easily imported in the pulumi scripts by name. This environment is part of `datarobot-user-models` (https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents)
