### PR TITLE
Add Dataset, Project, Leaderboard and RefreshPolicy resources

### DIFF
--- a/src/datarobot_pulumi_utils/pulumi/dataset_provider.py
+++ b/src/datarobot_pulumi_utils/pulumi/dataset_provider.py
@@ -40,6 +40,4 @@ class DataRobotDatasetResource(Resource):
         dataset_id: Input[str],
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
-        super().__init__(
-            DataRobotDatasetProvider(), name, {"dataset_id": dataset_id}, opts
-        )
+        super().__init__(DataRobotDatasetProvider(), name, {"dataset_id": dataset_id}, opts)

--- a/src/datarobot_pulumi_utils/pulumi/dataset_provider.py
+++ b/src/datarobot_pulumi_utils/pulumi/dataset_provider.py
@@ -1,0 +1,45 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Optional
+
+import datarobot as dr
+import pulumi
+from pulumi import Input
+from pulumi.dynamic import CreateResult, Resource, ResourceProvider
+
+
+class DataRobotDatasetProvider(ResourceProvider):
+    def create(self, props: Dict[str, Any]) -> CreateResult:
+        # No-op
+        return CreateResult(id_=props["dataset_id"], outs={})
+
+    def delete(self, id: str, props: Dict[str, Any]) -> None:
+        try:
+            pulumi.log.info(f"Attempting to delete dataset with ID: {id}")
+            dr.Dataset.delete(id)
+        except Exception:
+            pass
+
+
+class DataRobotDatasetResource(Resource):
+    def __init__(
+        self,
+        name: str,
+        dataset_id: Input[str],
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ) -> None:
+        super().__init__(
+            DataRobotDatasetProvider(), name, {"dataset_id": dataset_id}, opts
+        )

--- a/src/datarobot_pulumi_utils/pulumi/dataset_refresh_provider.py
+++ b/src/datarobot_pulumi_utils/pulumi/dataset_refresh_provider.py
@@ -58,9 +58,7 @@ class RefreshPolicyProvider(ResourceProvider):
         dataset_id, refresh_id = id.split(":")
         client.delete(f"datasets/{dataset_id}/refreshJobs/{refresh_id}")
 
-    def update(
-        self, id: str, olds: Dict[str, Any], news: Dict[str, Any]
-    ) -> UpdateResult:
+    def update(self, id: str, olds: Dict[str, Any], news: Dict[str, Any]) -> UpdateResult:
         self.delete(id, olds)
         create_result = self.create(news)
         return UpdateResult(outs=create_result.outs)

--- a/src/datarobot_pulumi_utils/pulumi/dataset_refresh_provider.py
+++ b/src/datarobot_pulumi_utils/pulumi/dataset_refresh_provider.py
@@ -1,0 +1,84 @@
+# Copyright 2024 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Any, Dict, Optional, Union
+
+import datarobot as dr
+import pulumi
+from pulumi import Input
+from pulumi.dynamic import CreateResult, ResourceProvider, UpdateResult
+
+client = dr.Client()
+
+
+def schedule_dataset_refresh(
+    dataset_id: str, credential_id: str, name: str, schedule: Union[Dict[str, Any], str]
+) -> str:
+    """Schedule a dataset refresh job"""
+    if isinstance(schedule, str):
+        schedule = json.loads(schedule)
+
+    resp = client.post(
+        f"datasets/{dataset_id}/refreshJobs/",
+        {
+            "credentialId": credential_id,
+            "enabled": True,
+            "name": name,
+            "schedule": schedule,
+        },
+    )
+    data = resp.json()
+    return str(data["jobId"])
+
+
+class RefreshPolicyProvider(ResourceProvider):
+    def create(self, props: Dict[str, Any]) -> CreateResult:
+        dataset_id = props["dataset_id"]
+        credential_id = props["credential_id"]
+        name = props.get("name", "Data Refresh Job")
+        schedule = props.get("schedule", "{}")
+        refresh_id = schedule_dataset_refresh(dataset_id, credential_id, name, schedule)
+
+        outputs = {**props, "dataset_id": dataset_id, "refresh_id": refresh_id}
+        return CreateResult(id_=f"{dataset_id}:{refresh_id}", outs=outputs)
+
+    def delete(self, id: str, props: Dict[str, Any]) -> None:
+        dataset_id, refresh_id = id.split(":")
+        client.delete(f"datasets/{dataset_id}/refreshJobs/{refresh_id}")
+
+    def update(
+        self, id: str, olds: Dict[str, Any], news: Dict[str, Any]
+    ) -> UpdateResult:
+        self.delete(id, olds)
+        create_result = self.create(news)
+        return UpdateResult(outs=create_result.outs)
+
+
+class RefreshPolicyResource(pulumi.dynamic.Resource):
+    def __init__(
+        self,
+        name: str,
+        dataset_id: Input[str],
+        credential_id: Input[str],
+        schedule: Optional[Union[Dict[str, Any], str]] = None,
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ) -> None:
+        props = {
+            "dataset_id": dataset_id,
+            "credential_id": credential_id,
+            "name": name,
+            "schedule": schedule,
+        }
+        super().__init__(RefreshPolicyProvider(), name, props, opts)

--- a/src/datarobot_pulumi_utils/pulumi/project.py
+++ b/src/datarobot_pulumi_utils/pulumi/project.py
@@ -1,0 +1,75 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Optional
+
+import datarobot as dr
+import pulumi
+from pulumi import Input
+from pulumi.dynamic import CreateResult, Resource, ResourceProvider
+
+
+class DataRobotProjectProvider(ResourceProvider):
+    def create(self, props: Dict[str, Any]) -> CreateResult:
+        # No-op
+        return CreateResult(id_=props["project_id"], outs={})
+
+    def delete(self, id: str, props: Dict[str, Any]) -> None:
+        project_id = id
+        try:
+            project = dr.Project.get(project_id)
+            project.delete()
+            pulumi.log.info(f"Deleted DataRobot project {project_id}")
+        except Exception as e:
+            pulumi.log.warn(f"Failed to delete DataRobot project {project_id}: {e}")
+
+
+class DataRobotProjectResource(Resource):
+    def __init__(
+        self,
+        name: str,
+        project_id: Input[str],
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ) -> None:
+        super().__init__(
+            DataRobotProjectProvider(), name, {"project_id": project_id}, opts
+        )
+
+
+class LeaderboardModelProvider(ResourceProvider):
+    def create(self, props: Dict[str, Any]) -> CreateResult:
+        # No-op
+        return CreateResult(id_=f"{props['project_id']}/{props['model_id']}", outs={})
+
+    def delete(self, id: str, props: Dict[str, Any]) -> None:
+        project_id, model_id = id.split("/", 1)
+        try:
+            model = dr.Model.get(project_id, model_id)
+            model.delete()
+            pulumi.log.info(f"Deleted DataRobot model {model_id} from project {project_id}")
+        except Exception as e:
+            pulumi.log.warn(f"Failed to delete DataRobot model {model_id} from project {project_id}: {e}")
+
+
+class LeaderboardModelResource(Resource):
+    def __init__(
+        self,
+        name: str,
+        project_id: Input[str],
+        model_id: Input[str],
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ) -> None:
+        super().__init__(
+            LeaderboardModelProvider(), name, {"project_id": project_id, "model_id": model_id}, opts
+        )

--- a/src/datarobot_pulumi_utils/pulumi/project.py
+++ b/src/datarobot_pulumi_utils/pulumi/project.py
@@ -42,9 +42,7 @@ class DataRobotProjectResource(Resource):
         project_id: Input[str],
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
-        super().__init__(
-            DataRobotProjectProvider(), name, {"project_id": project_id}, opts
-        )
+        super().__init__(DataRobotProjectProvider(), name, {"project_id": project_id}, opts)
 
 
 class LeaderboardModelProvider(ResourceProvider):
@@ -70,6 +68,4 @@ class LeaderboardModelResource(Resource):
         model_id: Input[str],
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
-        super().__init__(
-            LeaderboardModelProvider(), name, {"project_id": project_id, "model_id": model_id}, opts
-        )
+        super().__init__(LeaderboardModelProvider(), name, {"project_id": project_id, "model_id": model_id}, opts)


### PR DESCRIPTION
## Summary
This pull request introduces new Pulumi resource providers and resources for managing DataRobot datasets, dataset refresh policies, projects, and leaderboard models. These changes aim to extend the functionality of the `datarobot_pulumi_utils` library to support more comprehensive infrastructure management for DataRobot resources.

### Dataset Management Enhancements:
* Added `DataRobotDatasetProvider` and `DataRobotDatasetResource` for managing datasets using Pulumi. The `create` method is a no-op, while the `delete` method uses the DataRobot API to remove datasets. (`src/datarobot_pulumi_utils/pulumi/dataset_provider.py`)

### Dataset Refresh Policy Management:
* Introduced `RefreshPolicyProvider` and `RefreshPolicyResource` to manage dataset refresh schedules. This includes scheduling refresh jobs via the DataRobot API and handling create, update, and delete operations for refresh policies. (`src/datarobot_pulumi_utils/pulumi/dataset_refresh_provider.py`)

### Project and Model Management:
* Added `DataRobotProjectProvider` and `DataRobotProjectResource` for managing DataRobot projects. The `delete` method removes projects via the DataRobot API, with logging for success or failure. (`src/datarobot_pulumi_utils/pulumi/project.py`)
* Added `LeaderboardModelProvider` and `LeaderboardModelResource` to manage leaderboard models within DataRobot projects. The `delete` method removes models from projects, with appropriate logging. (`src/datarobot_pulumi_utils/pulumi/project.py`)


## Rationale
