### PR TITLE
Fix dataset update logic

### DIFF
--- a/src/datarobot_pulumi_utils/pulumi/dataset_provider.py
+++ b/src/datarobot_pulumi_utils/pulumi/dataset_provider.py
@@ -17,13 +17,40 @@ from typing import Any, Dict, Optional
 import datarobot as dr
 import pulumi
 from pulumi import Input
-from pulumi.dynamic import CreateResult, Resource, ResourceProvider
+from pulumi.dynamic import CreateResult, Resource, ResourceProvider, dynamic
 
 
 class DataRobotDatasetProvider(ResourceProvider):
+    def _normalize_props(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize properties to handle default values consistently."""
+        return {
+            "dataset_id": props.get("dataset_id"),
+            "managed": props.get("managed", False) if props.get("managed") is not None else False,
+        }
+
+    def diff(self, _id: str, _olds: Dict[str, Any], _news: Dict[str, Any]) -> dynamic.DiffResult:
+        normalized_olds = self._normalize_props(_olds)
+        normalized_news = self._normalize_props(_news)
+
+        changes = False
+        replaces: list[str] = []
+
+        for key, new_value in normalized_news.items():
+            old_value = normalized_olds.get(key)
+            if old_value != new_value:
+                changes = True
+                if key == "dataset_id":
+                    replaces.append(key)
+
+        return dynamic.DiffResult(changes=changes, replaces=replaces, delete_before_replace=True)
+
     def create(self, props: Dict[str, Any]) -> CreateResult:
-        # No-op
-        return CreateResult(id_=props["dataset_id"], outs={})
+        normalized_props = self._normalize_props(props)
+        return CreateResult(id_=normalized_props["dataset_id"], outs={"dataset_id": normalized_props["dataset_id"]})
+
+    def update(self, id: str, _olds: Dict[str, Any], _news: Dict[str, Any]) -> dynamic.UpdateResult:
+        normalized_news = self._normalize_props(_news)
+        return dynamic.UpdateResult(outs={"dataset_id": normalized_news["dataset_id"]})
 
     def delete(self, id: str, props: Dict[str, Any]) -> None:
         managed = props.get("managed", False)
@@ -38,11 +65,17 @@ class DataRobotDatasetProvider(ResourceProvider):
 
 
 class DataRobotDatasetResource(Resource):
+    dataset_id: pulumi.Output[str]
+
     def __init__(
         self,
         name: str,
         dataset_id: Input[str],
-        managed: bool = False,
+        managed: Optional[bool] = False,
         opts: Optional[pulumi.ResourceOptions] = None,
     ) -> None:
-        super().__init__(DataRobotDatasetProvider(), name, {"dataset_id": dataset_id, "managed": managed}, opts)
+        props = {
+            "dataset_id": dataset_id,
+            "managed": managed,
+        }
+        super().__init__(DataRobotDatasetProvider(), name, props, opts)


### PR DESCRIPTION
This pull request introduces enhancements to the `DataRobotDatasetProvider` and `DataRobotDatasetResource` classes in `src/datarobot_pulumi_utils/pulumi/dataset_provider.py`. The changes focus on improving property normalization, adding support for resource updates, and refining the resource initialization process.

### Enhancements to `DataRobotDatasetProvider`:

* Added a `_normalize_props` method to standardize property handling, ensuring consistent default values for properties like `managed`.
* Implemented a `diff` method to detect changes in resource properties, enabling proper handling of replacements for specific keys (e.g., `dataset_id`).
* Updated the `create` method to use normalized properties for consistent behavior.
* Introduced an `update` method to support resource updates, ensuring outputs reflect the updated properties.

### Refinements to `DataRobotDatasetResource`:

* Added a `dataset_id` output property for better access to resource attributes.
* Adjusted the constructor to use a dictionary for properties, aligning with the normalized approach in the provider.


